### PR TITLE
Add Rhino 8 installer for Python helper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,68 @@
+# Rhino to PrusaSlicer bridge
+
+This repository contains a small Rhino Python helper that exports the current
+selection as a STEP file and opens it inside [PrusaSlicer](https://www.prusa3d.com/page/prusaslicer_424/).
+It is intended to be attached to a toolbar button so that a single click sends
+the active model to the slicer.
+
+## Features
+
+- Prompts for geometry if nothing is pre-selected.
+- Remembers the PrusaSlicer executable path using Rhino's sticky dictionary or
+  the `PRUSA_SLICER_PATH` environment variable.
+- Exports selected objects to a temporary `.step` file using Rhino's native
+  exporter.
+- Launches PrusaSlicer with the exported file as an argument.
+
+## Installation
+
+### Quick installer (Rhino 8)
+
+1. Run the installer from a terminal:
+   ```
+   python3 install.py
+   ```
+   The script locates your Rhino 8 *scripts* directory (e.g.
+   `%AppData%\McNeel\Rhinoceros\8.0\scripts` on Windows or
+   `~/Library/Application Support/McNeel/Rhinoceros/8.0/scripts` on macOS) and
+   copies `send_to_prusa.py` there. Use `--mode link` if you prefer a symlink
+   for easier updates.
+2. (Optional) Set the `PRUSA_SLICER_PATH` environment variable to the absolute
+   path of the PrusaSlicer executable. If not set, the script will prompt for
+   the location the first time it runs and remember it for subsequent sessions.
+   On macOS you can point the variable at the `.app` bundle itself, e.g.
+   `export PRUSA_SLICER_PATH="/Applications/PrusaSlicer.app"`.
+3. Create a toolbar button or alias that runs the script:
+   ```
+   ! _-RunPythonScript ("import send_to_prusa; send_to_prusa.send_to_prusaslicer()")
+   ```
+   For convenience you can assign the right-click action of the same button to
+   configure the PrusaSlicer path:
+   ```
+   ! _-RunPythonScript ("import send_to_prusa; send_to_prusa.set_prusaslicer_path()")
+   ```
+
+### Manual install
+
+If you prefer not to run the installer, copy `src/send_to_prusa.py` to your
+Rhino scripts directory manually (`%AppData%\McNeel\Rhinoceros\8.0\scripts`
+or `~/Library/Application Support/McNeel/Rhinoceros/8.0/scripts`). Afterwards
+follow steps 2 and 3 above.
+
+## Usage
+
+1. Select the geometry you want to slice.
+2. Click the toolbar button or run the alias configured above.
+3. Rhino writes the selection to a temporary STEP file and starts PrusaSlicer
+   with that file. The exported files are left in your temporary folder so you
+   can reuse them if needed.
+
+## Notes
+
+- STEP export requires Rhino's standard STEP plug-in to be installed and
+  licensed. If exporting fails, check the Rhino command line for details.
+- On macOS, choose the `PrusaSlicer.app` bundle when prompted (or use the
+  bundle path in `PRUSA_SLICER_PATH`). The script uses the `open -a` helper so
+  that Rhino for Mac launches the application the same way Finder would.
+- Linux builds of Rhino are not officially supported, but the script will try
+  to launch whichever executable path you provide.

--- a/install.py
+++ b/install.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Installer utility for the Rhino ➜ PrusaSlicer bridge.
+
+Running this script copies (or links) the Rhino helper into Rhino's scripts
+folder so that ``RunPythonScript`` and toolbar buttons can import it. The
+installer auto-detects the Rhino 8 user data directory on Windows and macOS,
+but the target can be overridden via the command line.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+SCRIPT_NAME = "send_to_prusa.py"
+DEFAULT_VERSION = "8.0"
+
+
+def _detect_rhino_scripts_dir(version: str) -> Path:
+    """Best-effort detection of the Rhino scripts directory.
+
+    Parameters
+    ----------
+    version:
+        Rhino user folder version (e.g. ``"8.0"``).
+    """
+
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            base = Path(appdata)
+        else:
+            base = Path.home() / "AppData" / "Roaming"
+        return base / "McNeel" / "Rhinoceros" / version / "scripts"
+
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support" / "McNeel" / "Rhinoceros"
+        return base / version / "scripts"
+
+    # Rhino 8 is only supported on Windows and macOS, but fall back to a
+    # reasonable XDG location so the installer still works in testing setups.
+    base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "McNeel" / "Rhinoceros" / version / "scripts"
+
+
+def _copy_or_link(source: Path, destination: Path, *, mode: str, dry_run: bool) -> None:
+    if destination.exists() or destination.is_symlink():
+        if dry_run:
+            action = "would replace"
+        else:
+            if destination.is_dir() and not destination.is_symlink():
+                raise RuntimeError(f"Destination {destination} is a directory, aborting")
+            destination.unlink()
+            action = "replaced"
+        print(f"Existing {destination} {action}.")
+
+    if dry_run:
+        print(f"Would {mode} {source} -> {destination}")
+        return
+
+    if mode == "copy":
+        shutil.copy2(source, destination)
+    else:
+        destination.symlink_to(source)
+
+    print(f"Installed {destination} ({mode}).")
+
+
+def install_plugin(*, scripts_dir: Path, mode: str, dry_run: bool) -> Path:
+    source = Path(__file__).resolve().parent / "src" / SCRIPT_NAME
+    if not source.exists():
+        raise FileNotFoundError(f"Unable to locate {SCRIPT_NAME} next to the installer")
+
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    destination = scripts_dir / SCRIPT_NAME
+    _copy_or_link(source, destination, mode=mode, dry_run=dry_run)
+    return destination
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Install the RhinoToSlicer helper into Rhino 8.")
+    parser.add_argument(
+        "--scripts-dir",
+        type=Path,
+        help="Override the Rhino scripts directory. Defaults to the Rhino 8 user folder for the current OS.",
+    )
+    parser.add_argument(
+        "--version",
+        default=DEFAULT_VERSION,
+        help="Rhino user folder version (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("copy", "link"),
+        default="copy",
+        help="Install mode: copy the script (default) or create a symlink for easier updates.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without touching the filesystem.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+
+    if args.scripts_dir:
+        scripts_dir = args.scripts_dir.expanduser().resolve()
+    else:
+        scripts_dir = _detect_rhino_scripts_dir(args.version)
+
+    print(f"Target Rhino scripts directory: {scripts_dir}")
+
+    try:
+        destination = install_plugin(scripts_dir=scripts_dir, mode=args.mode, dry_run=args.dry_run)
+    except Exception as exc:  # pragma: no cover - installer level error
+        print(f"Installation failed: {exc}")
+        return 1
+
+    if args.dry_run:
+        print("Dry run complete. No files were modified.")
+    else:
+        print("Installation complete.")
+        print(
+            "In Rhino, create a button or alias with:\n"
+            "! _-RunPythonScript (\"import send_to_prusa; send_to_prusa.send_to_prusaslicer()\")"
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    raise SystemExit(main())

--- a/src/send_to_prusa.py
+++ b/src/send_to_prusa.py
@@ -1,0 +1,190 @@
+"""Send selected Rhino geometry to PrusaSlicer.
+
+This module provides helper functions that can be executed from Rhino's Python
+script editor or bound to toolbar buttons. The main entry point is the
+``send_to_prusaslicer`` function which exports the current selection to a
+STEP file and launches PrusaSlicer with the exported model.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import uuid
+from contextlib import contextmanager
+from typing import Iterable, Optional
+
+import Rhino
+import rhinoscriptsyntax as rs
+import scriptcontext as sc
+import System
+
+
+_PRUSA_PATH_KEY = "RhinoToSlicer::PrusaPath"
+_ENV_PATH_KEY = "PRUSA_SLICER_PATH"
+_DEFAULT_EXTENSION = ".step"
+_MAC_APP_SUFFIX = ".app"
+_MAC_APP_EXECUTABLE = os.path.join("Contents", "MacOS", "PrusaSlicer")
+
+
+def _is_windows() -> bool:
+    return System.Environment.OSVersion.Platform == System.PlatformID.Win32NT
+
+
+def _is_macos() -> bool:
+    platform = System.Environment.OSVersion.Platform
+    return platform == System.PlatformID.MacOSX or platform == System.PlatformID.Unix
+
+
+def _normalize_prusa_path(path: str) -> Optional[str]:
+    if not path:
+        return None
+    path = os.path.expanduser(path)
+    if _is_macos():
+        lower = path.lower()
+        if lower.endswith(_MAC_APP_SUFFIX):
+            if os.path.isdir(path):
+                app_binary = os.path.join(path, _MAC_APP_EXECUTABLE)
+                if os.path.isfile(app_binary) or os.access(app_binary, os.X_OK):
+                    return os.path.normpath(path)
+            return None
+        if os.path.isfile(path) or os.access(path, os.X_OK):
+            return os.path.normpath(path)
+        return None
+    if os.path.isfile(path) or os.access(path, os.X_OK):
+        return os.path.normpath(path)
+    return None
+
+
+def _load_prusaslicer_path() -> Optional[str]:
+    env_path = os.environ.get(_ENV_PATH_KEY)
+    env_path = _normalize_prusa_path(env_path) if env_path else None
+    if env_path:
+        sc.sticky[_PRUSA_PATH_KEY] = env_path
+        return env_path
+
+    sticky_path = sc.sticky.get(_PRUSA_PATH_KEY)
+    sticky_path = _normalize_prusa_path(sticky_path) if sticky_path else None
+    if sticky_path:
+        sc.sticky[_PRUSA_PATH_KEY] = sticky_path
+        return sticky_path
+    return None
+
+
+def _prompt_for_prusaslicer() -> Optional[str]:
+    if _is_windows():
+        filter_string = "PrusaSlicer executable (*.exe)|*.exe||"
+    elif _is_macos():
+        filter_string = "PrusaSlicer (*.app;PrusaSlicer)|*.app;PrusaSlicer||"
+    else:
+        filter_string = "Executable (*.*)|*.*||"
+
+    path = rs.OpenFileName("Locate PrusaSlicer", filter_string)
+    if not path:
+        return None
+    return _normalize_prusa_path(path)
+
+
+def set_prusaslicer_path(path: Optional[str] = None) -> Optional[str]:
+    """Persist the path to the PrusaSlicer executable.
+
+    If *path* is omitted a file dialog is presented. The chosen path is stored
+    in Rhino's sticky dictionary so that future calls can reuse it. The helper
+    also respects the :data:`PRUSA_SLICER_PATH` environment variable.
+    """
+    if path:
+        candidate = _normalize_prusa_path(path)
+    else:
+        candidate = _prompt_for_prusaslicer()
+    if not candidate:
+        print("PrusaSlicer path not set.")
+        return None
+
+    sc.sticky[_PRUSA_PATH_KEY] = candidate
+    print("Stored PrusaSlicer path: {}".format(candidate))
+    return candidate
+
+
+@contextmanager
+def _preserve_selection(new_selection: Iterable) -> Iterable:
+    previous = rs.SelectedObjects() or []
+    try:
+        rs.UnselectAllObjects()
+        if new_selection:
+            rs.SelectObjects(list(new_selection))
+        yield new_selection
+    finally:
+        rs.UnselectAllObjects()
+        if previous:
+            rs.SelectObjects(previous)
+
+
+def _export_selection(temp_path: str) -> bool:
+    options = Rhino.FileIO.FileWriteOptions()
+    options.WriteSelectedObjectsOnly = True
+    options.SuppressDialogBoxes = True
+    if sc.doc.ExportSelected(temp_path, options):
+        return os.path.exists(temp_path)
+    return False
+
+
+def _create_temp_export_path(extension: str = _DEFAULT_EXTENSION) -> str:
+    filename = "RhinoToPrusa_{}{}".format(uuid.uuid4().hex, extension)
+    return os.path.join(tempfile.gettempdir(), filename)
+
+
+def _launch_prusaslicer(prusa_path: str, model_path: str) -> None:
+    try:
+        if _is_macos():
+            lower = prusa_path.lower()
+            if lower.endswith(_MAC_APP_SUFFIX):
+                subprocess.Popen(["open", "-a", prusa_path, model_path])
+                return
+        subprocess.Popen([prusa_path, model_path])
+    except OSError as exc:
+        raise RuntimeError("Unable to start PrusaSlicer: {}".format(exc))
+
+
+def send_to_prusaslicer() -> Rhino.Commands.Result:
+    """Export the selected geometry to STEP and open it in PrusaSlicer."""
+    objects = rs.GetObjects(
+        "Select objects to send to PrusaSlicer",
+        preselect=True,
+        select=False,
+        minimum_count=1,
+    )
+    if not objects:
+        print("No geometry selected.")
+        return Rhino.Commands.Result.Cancel
+
+    prusa_path = _load_prusaslicer_path()
+    if not prusa_path:
+        prusa_path = set_prusaslicer_path()
+    if not prusa_path:
+        return Rhino.Commands.Result.Cancel
+
+    export_path = _create_temp_export_path()
+
+    with _preserve_selection(objects):
+        success = _export_selection(export_path)
+    if not success:
+        if os.path.exists(export_path):
+            try:
+                os.remove(export_path)
+            except OSError:
+                pass
+        print("Export failed. Check that the STEP exporter is installed and licensed.")
+        return Rhino.Commands.Result.Failure
+
+    try:
+        _launch_prusaslicer(prusa_path, export_path)
+    except RuntimeError as exc:
+        print(str(exc))
+        return Rhino.Commands.Result.Failure
+
+    print("Exported {} objects to {} and launched PrusaSlicer.".format(len(objects), export_path))
+    return Rhino.Commands.Result.Success
+
+
+if __name__ == "__main__":
+    send_to_prusaslicer()


### PR DESCRIPTION
## Summary
- add a CLI installer that detects the Rhino 8 scripts directory and installs the helper
- document the installer workflow and manual paths for Rhino 8 users

## Testing
- `python -m compileall src/send_to_prusa.py install.py`


------
https://chatgpt.com/codex/tasks/task_e_68d39e9abbd483238803c839f6092e0f