### PR TITLE
Add Rhino CPython plug-in bundle

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,15 +27,16 @@ active model to the slicer.
    The script locates your Rhino 8 user data folder (e.g.
    `%AppData%\McNeel\Rhinoceros\8.0` on Windows or
    `~/Library/Application Support/McNeel/Rhinoceros/8.0` on macOS), copies the
-   plug-in files (`send_to_prusa.py` and `__plugin__.py`) into
-   `Plug-ins/PythonPlugIns/SendToPrusa`, and prompts for the PrusaSlicer
+   plug-in files (`send_to_prusa.py`, `send_to_prusa_set_path.py`, and
+   `__plugin__.py`) into `Plug-ins/PythonPlugIns/SendToPrusa`, and prompts for the PrusaSlicer
    executable. Pass `--prusa-path /absolute/path` for a non-interactive setup or
    `--no-prusa-config` to skip the prompt entirely. Use `--mode link` if you
    prefer a symlink for easier updates.
-2. The installer also configures a Rhino alias named `SendToPrusa` that points
-   at the `SendToPrusa` command. Assign it to a toolbar button or run the
-   command directly from Rhino's command line. Use the companion command
-   `SendToPrusaSetPath` later if you need to change the slicer location.
+2. The installer also configures Rhino aliases named `SendToPrusa` and
+   `SendToPrusaSetPath` that call the plug-in scripts via `RunPythonScript`.
+   That makes the workflow available immediately—even if Rhino has not detected
+   the plug-in yet—and you can wire those aliases to toolbar buttons or run
+   them from Rhino's command line.
 3. Rhino should detect the plug-in automatically at the next launch. If it
    doesn't, open _Rhino Options → Plug-ins → Python → Install…_ and select the
    `Plug-ins/PythonPlugIns/SendToPrusa` folder. The plug-in appears in the list
@@ -43,17 +44,23 @@ active model to the slicer.
 
 ### Manual install
 
-If you prefer not to run the installer, copy `src/send_to_prusa.py` and
-`src/__plugin__.py` to your Rhino Python plug-in directory
-(`%AppData%\McNeel\Rhinoceros\8.0\Plug-ins\PythonPlugIns\SendToPrusa` or
-`~/Library/Application Support/McNeel/Rhinoceros/8.0/Plug-ins/PythonPlugIns/SendToPrusa`).
+If you prefer not to run the installer, copy `src/send_to_prusa.py`,
+`src/send_to_prusa_set_path.py`, and `src/__plugin__.py` to your Rhino Python
+plug-in directory (`%AppData%\McNeel\Rhinoceros\8.0\Plug-ins\PythonPlugIns\SendToPrusa`
+or `~/Library/Application Support/McNeel/Rhinoceros/8.0/Plug-ins/PythonPlugIns/SendToPrusa`).
 Launch Rhino, ensure the plug-in is loaded, and run:
 ```
 SendToPrusaSetPath
 ```
 to store the PrusaSlicer path. The first execution of `SendToPrusa` registers
 the matching Rhino alias so you can wire a toolbar button the same way as with
-the installer.
+the installer. You can also add aliases manually with the macros below if you
+skip the installer entirely:
+```
+! _-RunPythonScript ("/absolute/path/to/Plug-ins/PythonPlugIns/SendToPrusa/send_to_prusa.py")
+! _-RunPythonScript ("/absolute/path/to/Plug-ins/PythonPlugIns/SendToPrusa/send_to_prusa_set_path.py")
+```
+Adjust the paths to match the location where you copied the scripts.
 
 ## Usage
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,76 @@
+# Rhino to PrusaSlicer bridge
+
+This repository contains a Rhino CPython plug-in that exports the current
+selection as a STEP file and opens it inside
+[PrusaSlicer](https://www.prusa3d.com/page/prusaslicer_424/). Once installed, the
+plug-in contributes the `SendToPrusa` command so a single click can send the
+active model to the slicer.
+
+## Features
+
+- Rhino commands `SendToPrusa` (export and launch) and `SendToPrusaSetPath`
+  (update the PrusaSlicer executable).
+- Remembers the PrusaSlicer executable path using Rhino's sticky dictionary or
+  the `PRUSA_SLICER_PATH` environment variable.
+- Exports selected objects to a temporary `.step` file using Rhino's native
+  exporter.
+- Launches PrusaSlicer with the exported file as an argument.
+
+## Installation
+
+### Quick installer (Rhino 8)
+
+1. Run the installer from a terminal:
+   ```
+   python3 install.py
+   ```
+   The script locates your Rhino 8 user data folder (e.g.
+   `%AppData%\McNeel\Rhinoceros\8.0` on Windows or
+   `~/Library/Application Support/McNeel/Rhinoceros/8.0` on macOS), copies the
+   plug-in files (`send_to_prusa.py` and `__plugin__.py`) into
+   `Plug-ins/PythonPlugIns/SendToPrusa`, and prompts for the PrusaSlicer
+   executable. Pass `--prusa-path /absolute/path` for a non-interactive setup or
+   `--no-prusa-config` to skip the prompt entirely. Use `--mode link` if you
+   prefer a symlink for easier updates.
+2. The installer also configures a Rhino alias named `SendToPrusa` that points
+   at the `SendToPrusa` command. Assign it to a toolbar button or run the
+   command directly from Rhino's command line. Use the companion command
+   `SendToPrusaSetPath` later if you need to change the slicer location.
+3. Rhino should detect the plug-in automatically at the next launch. If it
+   doesn't, open _Rhino Options → Plug-ins → Python → Install…_ and select the
+   `Plug-ins/PythonPlugIns/SendToPrusa` folder. The plug-in appears in the list
+   as **RhinoToPrusa**.
+
+### Manual install
+
+If you prefer not to run the installer, copy `src/send_to_prusa.py` and
+`src/__plugin__.py` to your Rhino Python plug-in directory
+(`%AppData%\McNeel\Rhinoceros\8.0\Plug-ins\PythonPlugIns\SendToPrusa` or
+`~/Library/Application Support/McNeel/Rhinoceros/8.0/Plug-ins/PythonPlugIns/SendToPrusa`).
+Launch Rhino, ensure the plug-in is loaded, and run:
+```
+SendToPrusaSetPath
+```
+to store the PrusaSlicer path. The first execution of `SendToPrusa` registers
+the matching Rhino alias so you can wire a toolbar button the same way as with
+the installer.
+
+## Usage
+
+1. Select the geometry you want to slice (or let the command prompt for it).
+2. Run the `SendToPrusa` command (or click the toolbar button tied to the alias).
+3. Rhino writes the selection to a temporary STEP file and starts PrusaSlicer
+   with that file. The exported files remain in your temporary folder so you can
+   reuse them if needed.
+
+## Notes
+
+- STEP export requires Rhino's standard STEP plug-in to be installed and
+  licensed. If exporting fails, check the Rhino command line for details.
+- On macOS, choose the `PrusaSlicer.app` bundle when prompted (or use the bundle
+  path in `PRUSA_SLICER_PATH`). The plug-in uses the `open -a` helper so Rhino
+  for Mac launches the application the same way Finder would.
+- Linux builds of Rhino are not officially supported, but the plug-in will try
+  to launch whichever executable path you provide.
+- The installer stores configuration in `send_to_prusa_config.json` inside the
+  plug-in folder so the slicer path persists across Rhino sessions.

--- a/install.py
+++ b/install.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Installer utility for the Rhino ➜ PrusaSlicer bridge."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+SCRIPT_NAME = "send_to_prusa.py"
+PLUGIN_ENTRY_NAME = "__plugin__.py"
+PLUGIN_DIR_NAME = "SendToPrusa"
+CONFIG_FILENAME = "send_to_prusa_config.json"
+ALIAS_NAME = "SendToPrusa"
+ALIAS_MACRO = "! _SendToPrusa"
+DEFAULT_VERSION = "8.0"
+
+
+def _detect_rhino_user_dir(version: str) -> Path:
+    """Locate Rhino's per-user data directory for the given version."""
+
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        return base / "McNeel" / "Rhinoceros" / version
+
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support" / "McNeel" / "Rhinoceros"
+        return base / version
+
+    base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "McNeel" / "Rhinoceros" / version
+
+
+def _detect_plugin_dir(user_dir: Path) -> Path:
+    return user_dir / "Plug-ins" / "PythonPlugIns" / PLUGIN_DIR_NAME
+
+
+def _normalize_prusa_path(path: str) -> Optional[str]:
+    path = os.path.expanduser(path)
+    if not path:
+        return None
+    if sys.platform == "darwin":
+        lower = path.lower()
+        if lower.endswith(".app"):
+            bundle_binary = os.path.join(path, "Contents", "MacOS", "PrusaSlicer")
+            if os.path.isdir(path) and (os.path.isfile(bundle_binary) or os.access(bundle_binary, os.X_OK)):
+                return os.path.normpath(path)
+            return None
+    if os.path.isfile(path) or os.access(path, os.X_OK):
+        return os.path.normpath(path)
+    return None
+
+
+def _prompt_for_prusa_path(existing: Optional[str]) -> Optional[str]:
+    hint = f" [{existing}]" if existing else ""
+    response = input(f"Path to PrusaSlicer executable or app{hint}: ").strip()
+    if not response:
+        return existing
+    normalized = _normalize_prusa_path(response)
+    if not normalized:
+        print("Provided path is not executable. Please verify and re-run.")
+    return normalized
+
+
+def _config_file_for(destination: Path) -> Path:
+    return destination.with_name(CONFIG_FILENAME)
+
+
+def _write_config(destination: Path, prusa_path: str, *, dry_run: bool) -> None:
+    config_path = _config_file_for(destination)
+    payload = {"prusa_path": prusa_path}
+    if dry_run:
+        print(f"Would store PrusaSlicer path in {config_path}")
+        return
+    config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Stored PrusaSlicer path in {config_path}")
+
+
+def _load_existing_config(destination: Path) -> Optional[str]:
+    config_path = _config_file_for(destination)
+    if not config_path.exists():
+        return None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    path = data.get("prusa_path")
+    return _normalize_prusa_path(path) if path else None
+
+
+def _configure_prusa_path(destination: Path, provided: Optional[str], *, dry_run: bool) -> None:
+    normalized = _normalize_prusa_path(provided) if provided else None
+    if provided and not normalized:
+        print(f"Ignoring invalid PrusaSlicer path: {provided}")
+    if not normalized:
+        existing = _load_existing_config(destination)
+        normalized = _prompt_for_prusa_path(existing)
+    if not normalized:
+        print("PrusaSlicer path not stored. You can run the installer again with --prusa-path.")
+        return
+    _write_config(destination, normalized, dry_run=dry_run)
+
+
+def _alias_file(user_dir: Path) -> Path:
+    return user_dir / "settings" / "aliases.txt"
+
+
+def _ensure_alias(user_dir: Path, alias: str, macro: str, *, dry_run: bool) -> bool:
+    alias_path = _alias_file(user_dir)
+    alias_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_content = ""
+    if alias_path.exists():
+        try:
+            existing_content = alias_path.read_text(encoding="utf-8")
+        except OSError:
+            print(f"Unable to read {alias_path}; skipping alias configuration.")
+            return False
+        lowered = existing_content.lstrip().lower()
+        if lowered.startswith("<"):
+            print(
+                f"Alias file {alias_path} appears to be XML. Please add the alias manually in Rhino Options."
+            )
+            return False
+        normalized_lines = [line.strip() for line in existing_content.replace("\r\n", "\n").split("\n")]
+        for line in normalized_lines:
+            if not line or line.startswith("#") or line.startswith(";"):
+                continue
+            if "=" not in line:
+                continue
+            name, _ = line.split("=", 1)
+            if name.strip().lower() == alias.lower():
+                print(f"Alias '{alias}' already configured in {alias_path}.")
+                return True
+    line = f"{alias}={macro}"
+    if dry_run:
+        print(f"Would append alias to {alias_path}: {line}")
+        return True
+    prefix = ""
+    if alias_path.exists() and existing_content and not existing_content.endswith("\n"):
+        prefix = "\n"
+    try:
+        with alias_path.open("a", encoding="utf-8") as stream:
+            stream.write(prefix + line + "\n")
+    except OSError as exc:
+        print(f"Failed to update {alias_path}: {exc}")
+        return False
+    print(f"Added '{alias}' alias to {alias_path}.")
+    return True
+
+
+def _copy_or_link(source: Path, destination: Path, *, mode: str, dry_run: bool) -> None:
+    if destination.exists() or destination.is_symlink():
+        if dry_run:
+            action = "would replace"
+        else:
+            if destination.is_dir() and not destination.is_symlink():
+                raise RuntimeError(f"Destination {destination} is a directory, aborting")
+            destination.unlink()
+            action = "replaced"
+        print(f"Existing {destination} {action}.")
+
+    if dry_run:
+        print(f"Would {mode} {source} -> {destination}")
+        return
+
+    if mode == "copy":
+        shutil.copy2(source, destination)
+    else:
+        destination.symlink_to(source)
+
+    print(f"Installed {destination} ({mode}).")
+
+
+def install_plugin_bundle(*, plugin_dir: Path, mode: str, dry_run: bool) -> Path:
+    source_root = Path(__file__).resolve().parent / "src"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    for filename in (SCRIPT_NAME, PLUGIN_ENTRY_NAME):
+        source = source_root / filename
+        if not source.exists():
+            raise FileNotFoundError(f"Unable to locate {filename} next to the installer")
+        destination = plugin_dir / filename
+        _copy_or_link(source, destination, mode=mode, dry_run=dry_run)
+    return plugin_dir / SCRIPT_NAME
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Install the RhinoToSlicer plug-in into Rhino 8.")
+    parser.add_argument(
+        "--scripts-dir",
+        type=Path,
+        help="Override the Rhino scripts directory (used to locate the user profile). Defaults to the Rhino 8 user folder.",
+    )
+    parser.add_argument(
+        "--plugin-dir",
+        type=Path,
+        help="Override the target Python plug-in directory.",
+    )
+    parser.add_argument(
+        "--version",
+        default=DEFAULT_VERSION,
+        help="Rhino user folder version (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("copy", "link"),
+        default="copy",
+        help="Install mode: copy the files (default) or create symlinks for easier updates.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without touching the filesystem.",
+    )
+    parser.add_argument(
+        "--no-prusa-config",
+        dest="configure_prusa",
+        action="store_false",
+        help="Skip prompting for the PrusaSlicer executable during installation.",
+    )
+    parser.add_argument(
+        "--prusa-path",
+        help="Set the PrusaSlicer executable path non-interactively (overrides the interactive prompt).",
+    )
+    parser.add_argument(
+        "--alias-name",
+        default=ALIAS_NAME,
+        help="Name of the Rhino command alias to create (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--no-alias",
+        action="store_true",
+        help="Skip configuring the Rhino command alias.",
+    )
+    parser.set_defaults(configure_prusa=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+
+    if args.scripts_dir:
+        user_dir = args.scripts_dir.expanduser().resolve().parent
+    else:
+        user_dir = _detect_rhino_user_dir(args.version)
+
+    if args.plugin_dir:
+        plugin_dir = args.plugin_dir.expanduser().resolve()
+    else:
+        plugin_dir = _detect_plugin_dir(user_dir)
+
+    print(f"Target Rhino plug-in directory: {plugin_dir}")
+
+    try:
+        destination = install_plugin_bundle(plugin_dir=plugin_dir, mode=args.mode, dry_run=args.dry_run)
+    except Exception as exc:  # pragma: no cover - installer level error
+        print(f"Installation failed: {exc}")
+        return 1
+
+    configure_prusa = args.configure_prusa or bool(args.prusa_path)
+    if configure_prusa:
+        if args.dry_run and not args.prusa_path:
+            print("Skipping PrusaSlicer path prompt during dry run.")
+        else:
+            _configure_prusa_path(destination, args.prusa_path, dry_run=args.dry_run)
+
+    alias_configured = True
+    if not args.no_alias:
+        alias_configured = _ensure_alias(user_dir, args.alias_name, ALIAS_MACRO, dry_run=args.dry_run)
+
+    if args.dry_run:
+        print("Dry run complete. No files were modified.")
+    else:
+        print("Installation complete.")
+        if args.no_alias:
+            print("Add a button or alias manually with:\n! _SendToPrusa")
+        elif alias_configured:
+            print(
+                f"Rhino alias '{args.alias_name}' now maps to the SendToPrusa command. Assign it to a toolbar button or run it directly."
+            )
+        else:
+            print(
+                f"Unable to update Rhino's alias list automatically. Add '{args.alias_name}' manually with:\n{ALIAS_MACRO}"
+            )
+        print(
+            "Load the plug-in from Rhino's Plug-in manager if it isn't detected automatically and run 'SendToPrusaSetPath' to update the slicer path."
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    raise SystemExit(main())

--- a/install.py
+++ b/install.py
@@ -1,13 +1,14 @@
-#!/usr/bin/env python3
-"""Installer utility for the Rhino ➜ PrusaSlicer bridge."""
+#!/usr/bin/env python
+"""Installer utility for the Rhino to PrusaSlicer bridge."""
+
+from __future__ import print_function
 
 import argparse
+import io
 import json
 import os
 import shutil
 import sys
-from pathlib import Path
-from typing import Dict, List, Optional
 
 SCRIPT_NAME = "send_to_prusa.py"
 SET_PATH_SCRIPT_NAME = "send_to_prusa_set_path.py"
@@ -17,36 +18,60 @@ CONFIG_FILENAME = "send_to_prusa_config.json"
 ALIAS_NAME = "SendToPrusa"
 DEFAULT_VERSION = "8.0"
 
+try:
+    input_function = raw_input  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - Python 3 fallback for local testing
+    input_function = input
 
-def _detect_rhino_user_dir(version: str) -> Path:
+
+def _detect_rhino_user_dir(version):
     """Locate Rhino's per-user data directory for the given version."""
 
     if sys.platform.startswith("win"):
         appdata = os.environ.get("APPDATA")
-        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
-        return base / "McNeel" / "Rhinoceros" / version
+        if appdata:
+            base = appdata
+        else:
+            base = os.path.join(os.path.expanduser("~"), "AppData", "Roaming")
+        return os.path.join(base, "McNeel", "Rhinoceros", version)
 
     if sys.platform == "darwin":
-        base = Path.home() / "Library" / "Application Support" / "McNeel" / "Rhinoceros"
-        return base / version
+        base = os.path.join(
+            os.path.expanduser("~"), "Library", "Application Support", "McNeel", "Rhinoceros"
+        )
+        return os.path.join(base, version)
 
-    base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return base / "McNeel" / "Rhinoceros" / version
+    base = os.environ.get(
+        "XDG_DATA_HOME",
+        os.path.join(os.path.expanduser("~"), ".local", "share"),
+    )
+    return os.path.join(base, "McNeel", "Rhinoceros", version)
 
 
-def _detect_plugin_dir(user_dir: Path) -> Path:
-    return user_dir / "Plug-ins" / "PythonPlugIns" / PLUGIN_DIR_NAME
+def _detect_plugin_dir(user_dir):
+    return os.path.join(user_dir, "Plug-ins", "PythonPlugIns", PLUGIN_DIR_NAME)
 
 
-def _normalize_prusa_path(path: str) -> Optional[str]:
-    path = os.path.expanduser(path)
+def _ensure_directory(path):
+    if not os.path.isdir(path):
+        try:
+            os.makedirs(path)
+        except OSError:
+            if not os.path.isdir(path):
+                raise
+
+
+def _normalize_prusa_path(path):
     if not path:
         return None
+    path = os.path.expanduser(path)
     if sys.platform == "darwin":
         lower = path.lower()
         if lower.endswith(".app"):
             bundle_binary = os.path.join(path, "Contents", "MacOS", "PrusaSlicer")
-            if os.path.isdir(path) and (os.path.isfile(bundle_binary) or os.access(bundle_binary, os.X_OK)):
+            if os.path.isdir(path) and (
+                os.path.isfile(bundle_binary) or os.access(bundle_binary, os.X_OK)
+            ):
                 return os.path.normpath(path)
             return None
     if os.path.isfile(path) or os.access(path, os.X_OK):
@@ -54,9 +79,12 @@ def _normalize_prusa_path(path: str) -> Optional[str]:
     return None
 
 
-def _prompt_for_prusa_path(existing: Optional[str]) -> Optional[str]:
-    hint = f" [{existing}]" if existing else ""
-    response = input(f"Path to PrusaSlicer executable or app{hint}: ").strip()
+def _prompt_for_prusa_path(existing):
+    if existing:
+        hint = " [{}]".format(existing)
+    else:
+        hint = ""
+    response = input_function("Path to PrusaSlicer executable or app{}: ".format(hint)).strip()
     if not response:
         return existing
     normalized = _normalize_prusa_path(response)
@@ -65,71 +93,81 @@ def _prompt_for_prusa_path(existing: Optional[str]) -> Optional[str]:
     return normalized
 
 
-def _config_file_for(destination: Path) -> Path:
-    return destination.with_name(CONFIG_FILENAME)
+def _config_file_for(script_path):
+    return os.path.join(os.path.dirname(script_path), CONFIG_FILENAME)
 
 
-def _write_config(destination: Path, prusa_path: str, *, dry_run: bool) -> None:
-    config_path = _config_file_for(destination)
-    payload = {"prusa_path": prusa_path}
+def _write_config(script_path, prusa_path, dry_run):
+    config_path = _config_file_for(script_path)
     if dry_run:
-        print(f"Would store PrusaSlicer path in {config_path}")
+        print("Would store PrusaSlicer path in {}".format(config_path))
         return
-    config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    print(f"Stored PrusaSlicer path in {config_path}")
+    payload = json.dumps({"prusa_path": prusa_path}, indent=2)
+    with io.open(config_path, "w", encoding="utf-8") as stream:
+        stream.write(payload)
+    print("Stored PrusaSlicer path in {}".format(config_path))
 
 
-def _load_existing_config(destination: Path) -> Optional[str]:
-    config_path = _config_file_for(destination)
-    if not config_path.exists():
+def _load_existing_config(script_path):
+    config_path = _config_file_for(script_path)
+    if not os.path.exists(config_path):
         return None
     try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        with io.open(config_path, "r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (IOError, ValueError):
         return None
     path = data.get("prusa_path")
-    return _normalize_prusa_path(path) if path else None
+    if not path:
+        return None
+    return _normalize_prusa_path(path)
 
 
-def _configure_prusa_path(destination: Path, provided: Optional[str], *, dry_run: bool) -> None:
+def _configure_prusa_path(script_path, provided, dry_run):
     normalized = _normalize_prusa_path(provided) if provided else None
     if provided and not normalized:
-        print(f"Ignoring invalid PrusaSlicer path: {provided}")
+        print("Ignoring invalid PrusaSlicer path: {}".format(provided))
     if not normalized:
-        existing = _load_existing_config(destination)
+        existing = _load_existing_config(script_path)
         normalized = _prompt_for_prusa_path(existing)
     if not normalized:
         print("PrusaSlicer path not stored. You can run the installer again with --prusa-path.")
         return
-    _write_config(destination, normalized, dry_run=dry_run)
+    _write_config(script_path, normalized, dry_run)
 
 
-def _alias_file(user_dir: Path) -> Path:
-    return user_dir / "settings" / "aliases.txt"
+def _alias_file(user_dir):
+    return os.path.join(user_dir, "settings", "aliases.txt")
 
 
-def _build_run_python_macro(script_path: Path) -> str:
-    quoted = script_path.as_posix()
-    return f'! _-RunPythonScript ("{quoted}")'
+def _build_run_python_macro(script_path):
+    normalized = script_path.replace("\\", "/")
+    return '! _-RunPythonScript ("{}")'.format(normalized)
 
 
-def _ensure_alias(user_dir: Path, alias: str, macro: str, *, dry_run: bool) -> bool:
+def _ensure_alias(user_dir, alias, macro, dry_run):
     alias_path = _alias_file(user_dir)
-    alias_path.parent.mkdir(parents=True, exist_ok=True)
+    alias_dir = os.path.dirname(alias_path)
+    _ensure_directory(alias_dir)
     existing_content = ""
-    if alias_path.exists():
+    if os.path.exists(alias_path):
         try:
-            existing_content = alias_path.read_text(encoding="utf-8")
-        except OSError:
-            print(f"Unable to read {alias_path}; skipping alias configuration.")
+            with io.open(alias_path, "r", encoding="utf-8") as stream:
+                existing_content = stream.read()
+        except IOError:
+            print("Unable to read {}; skipping alias configuration.".format(alias_path))
             return False
         lowered = existing_content.lstrip().lower()
         if lowered.startswith("<"):
             print(
-                f"Alias file {alias_path} appears to be XML. Please add the alias manually in Rhino Options."
+                "Alias file {} appears to be XML. Please add the alias manually in Rhino Options.".format(
+                    alias_path
+                )
             )
             return False
-        normalized_lines = [line.strip() for line in existing_content.replace("\r\n", "\n").split("\n")]
+        normalized_lines = [
+            line.strip() for line in existing_content.replace("\r\n", "\n").split("\n")
+        ]
         for line in normalized_lines:
             if not line or line.startswith("#") or line.startswith(";"):
                 continue
@@ -137,72 +175,69 @@ def _ensure_alias(user_dir: Path, alias: str, macro: str, *, dry_run: bool) -> b
                 continue
             name, _ = line.split("=", 1)
             if name.strip().lower() == alias.lower():
-                print(f"Alias '{alias}' already configured in {alias_path}.")
+                print("Alias '{}' already configured in {}.".format(alias, alias_path))
                 return True
-    line = f"{alias}={macro}"
+    line = "{}={}".format(alias, macro)
     if dry_run:
-        print(f"Would append alias to {alias_path}: {line}")
+        print("Would append alias to {}: {}".format(alias_path, line))
         return True
     prefix = ""
-    if alias_path.exists() and existing_content and not existing_content.endswith("\n"):
+    if existing_content and not existing_content.endswith("\n"):
         prefix = "\n"
     try:
-        with alias_path.open("a", encoding="utf-8") as stream:
+        with io.open(alias_path, "a", encoding="utf-8") as stream:
             stream.write(prefix + line + "\n")
-    except OSError as exc:
-        print(f"Failed to update {alias_path}: {exc}")
+    except IOError as exc:
+        print("Failed to update {}: {}".format(alias_path, exc))
         return False
-    print(f"Added '{alias}' alias to {alias_path}.")
+    print("Added '{}' alias to {}.".format(alias, alias_path))
     return True
 
 
-def _copy_or_link(source: Path, destination: Path, *, mode: str, dry_run: bool) -> None:
-    if destination.exists() or destination.is_symlink():
+def _copy_or_link(source, destination, mode, dry_run):
+    if os.path.lexists(destination):
         if dry_run:
             action = "would replace"
         else:
-            if destination.is_dir() and not destination.is_symlink():
-                raise RuntimeError(f"Destination {destination} is a directory, aborting")
-            destination.unlink()
+            if os.path.isdir(destination) and not os.path.islink(destination):
+                raise RuntimeError("Destination {} is a directory, aborting".format(destination))
+            os.unlink(destination)
             action = "replaced"
-        print(f"Existing {destination} {action}.")
-
+        print("Existing {} {}.".format(destination, action))
     if dry_run:
-        print(f"Would {mode} {source} -> {destination}")
+        print("Would {} {} -> {}".format(mode, source, destination))
         return
-
     if mode == "copy":
         shutil.copy2(source, destination)
     else:
-        destination.symlink_to(source)
+        os.symlink(source, destination)
+    print("Installed {} ({}).".format(destination, mode))
 
-    print(f"Installed {destination} ({mode}).")
 
-
-def install_plugin_bundle(*, plugin_dir: Path, mode: str, dry_run: bool) -> Dict[str, Path]:
-    source_root = Path(__file__).resolve().parent / "src"
-    plugin_dir.mkdir(parents=True, exist_ok=True)
-    installed: Dict[str, Path] = {}
+def install_plugin_bundle(plugin_dir, mode, dry_run):
+    source_root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
+    _ensure_directory(plugin_dir)
+    installed = {}
     for filename in (SCRIPT_NAME, SET_PATH_SCRIPT_NAME, PLUGIN_ENTRY_NAME):
-        source = source_root / filename
-        if not source.exists():
-            raise FileNotFoundError(f"Unable to locate {filename} next to the installer")
-        destination = plugin_dir / filename
+        source = os.path.join(source_root, filename)
+        if not os.path.exists(source):
+            raise IOError("Unable to locate {} next to the installer".format(filename))
+        destination = os.path.join(plugin_dir, filename)
         _copy_or_link(source, destination, mode=mode, dry_run=dry_run)
         installed[filename] = destination
     return installed
 
 
-def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Install the RhinoToSlicer plug-in into Rhino 8.")
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Install the RhinoToSlicer plug-in into Rhino 8."
+    )
     parser.add_argument(
         "--scripts-dir",
-        type=Path,
         help="Override the Rhino scripts directory (used to locate the user profile). Defaults to the Rhino 8 user folder.",
     )
     parser.add_argument(
         "--plugin-dir",
-        type=Path,
         help="Override the target Python plug-in directory.",
     )
     parser.add_argument(
@@ -245,27 +280,28 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv=None):
     args = parse_args(argv)
 
     if args.scripts_dir:
-        user_dir = args.scripts_dir.expanduser().resolve().parent
+        scripts_dir = os.path.abspath(os.path.expanduser(args.scripts_dir))
+        user_dir = os.path.dirname(scripts_dir)
     else:
         user_dir = _detect_rhino_user_dir(args.version)
 
     if args.plugin_dir:
-        plugin_dir = args.plugin_dir.expanduser().resolve()
+        plugin_dir = os.path.abspath(os.path.expanduser(args.plugin_dir))
     else:
         plugin_dir = _detect_plugin_dir(user_dir)
 
-    print(f"Target Rhino plug-in directory: {plugin_dir}")
+    print("Target Rhino plug-in directory: {}".format(plugin_dir))
 
     try:
         installed_files = install_plugin_bundle(
             plugin_dir=plugin_dir, mode=args.mode, dry_run=args.dry_run
         )
-    except Exception as exc:  # pragma: no cover - installer level error
-        print(f"Installation failed: {exc}")
+    except Exception as exc:
+        print("Installation failed: {}".format(exc))
         return 1
 
     send_script = installed_files[SCRIPT_NAME]
@@ -278,17 +314,20 @@ def main(argv: Optional[list[str]] = None) -> int:
         else:
             _configure_prusa_path(send_script, args.prusa_path, dry_run=args.dry_run)
 
-    alias_results: List[bool] = []
+    alias_results = []
     if not args.no_alias:
         send_macro = _build_run_python_macro(send_script)
         alias_results.append(
             _ensure_alias(user_dir, args.alias_name, send_macro, dry_run=args.dry_run)
         )
-        configure_alias = f"{args.alias_name}SetPath"
+        configure_alias = "{}SetPath".format(args.alias_name)
         configure_macro = _build_run_python_macro(configure_script)
         alias_results.append(
             _ensure_alias(user_dir, configure_alias, configure_macro, dry_run=args.dry_run)
         )
+    else:
+        configure_alias = "{}SetPath".format(args.alias_name)
+
     alias_configured = all(alias_results) if alias_results else True
 
     if args.dry_run:
@@ -298,17 +337,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         if args.no_alias:
             print(
                 "Add toolbar buttons or aliases manually with:\n"
-                f"! _-RunPythonScript (\"{send_script.as_posix()}\")\n"
-                f"! _-RunPythonScript (\"{configure_script.as_posix()}\")"
+                "! _-RunPythonScript (\"{}\")\n"
+                "! _-RunPythonScript (\"{}\")".format(
+                    send_script.replace("\\", "/"),
+                    configure_script.replace("\\", "/"),
+                )
             )
         elif alias_configured:
             print(
-                f"Rhino aliases '{args.alias_name}' and '{args.alias_name}SetPath' now execute the plug-in scripts."
+                "Rhino aliases '{}' and '{}' now execute the plug-in scripts.".format(
+                    args.alias_name, configure_alias
+                )
             )
         else:
             print(
                 "Unable to update Rhino's alias list automatically. Add the following manually:\n"
-                f"{send_macro}\n{configure_macro}"
+                "{}\n{}".format(send_macro, configure_macro)
             )
         print(
             "Load the plug-in from Rhino's Plug-in manager if it isn't detected automatically and run 'SendToPrusaSetPath' to update the slicer path."
@@ -316,5 +360,5 @@ def main(argv: Optional[list[str]] = None) -> int:
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - script entrypoint
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/install.py
+++ b/install.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Installer utility for the Rhino ➜ PrusaSlicer bridge."""
-from __future__ import annotations
 
 import argparse
 import json

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -33,7 +33,7 @@ class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
     instance = None
 
     def __init__(self):
-        super().__init__()
+        Rhino.PlugIns.PlugIn.__init__(self)
         RhinoToPrusaPlugIn.instance = self
 
     @property
@@ -60,7 +60,7 @@ class SendToPrusaCommand(Rhino.Commands.Command):
     instance = None
 
     def __init__(self):
-        super().__init__()
+        Rhino.Commands.Command.__init__(self)
         SendToPrusaCommand.instance = self
 
     def EnglishName(self):  # pragma: no cover - Rhino callback
@@ -78,7 +78,7 @@ class ConfigurePrusaPathCommand(Rhino.Commands.Command):
     instance = None
 
     def __init__(self):
-        super().__init__()
+        Rhino.Commands.Command.__init__(self)
         ConfigurePrusaPathCommand.instance = self
 
     def EnglishName(self):  # pragma: no cover - Rhino callback

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -25,7 +25,7 @@ __plugin_description__ = "Export selected Rhino geometry to PrusaSlicer."
 
 _PLUGIN_GUID = System.Guid(__plugin_id__)
 _SEND_ALIAS = send_to_prusa._ALIAS_NAME  # reuse the shared command name
-_CONFIGURE_COMMAND = f"{_SEND_ALIAS}SetPath"
+_CONFIGURE_COMMAND = send_to_prusa.SET_PATH_COMMAND_NAME
 
 
 class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -1,0 +1,98 @@
+"""Rhino CPython plug-in entry point for the Rhino ➜ PrusaSlicer bridge."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import Rhino
+import System
+
+# Ensure the helper module that performs the heavy lifting is importable. When
+# Rhino loads the plug-in it executes this module from the plug-in folder,
+# which also contains ``send_to_prusa.py``. Some Rhino configurations do not
+# automatically append that folder to ``sys.path`` when running CPython plug-ins,
+# so add it explicitly to keep imports reliable.
+_PLUGIN_DIR = Path(__file__).resolve().parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+import send_to_prusa  # noqa: E402  # pylint: disable=wrong-import-position
+
+__plugin_id__ = "4f0b3a66-0b2e-49fa-8ae2-2b3f707ceba9"
+__plugin_name__ = "RhinoToPrusa"
+__plugin_version__ = "0.3.0"
+__plugin_description__ = "Export selected Rhino geometry to PrusaSlicer."
+
+_PLUGIN_GUID = System.Guid(__plugin_id__)
+_SEND_ALIAS = send_to_prusa._ALIAS_NAME  # reuse the shared command name
+_CONFIGURE_COMMAND = f"{_SEND_ALIAS}SetPath"
+
+
+class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
+    """Minimal plug-in that exposes the Prusa commands in Rhino."""
+
+    instance: "RhinoToPrusaPlugIn" | None = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        RhinoToPrusaPlugIn.instance = self
+
+    @property
+    def Id(self) -> System.Guid:  # pragma: no cover - Rhino callback
+        return _PLUGIN_GUID
+
+    @property
+    def PlugInName(self) -> str:  # pragma: no cover - Rhino callback
+        return __plugin_name__
+
+    @property
+    def Version(self) -> str:  # pragma: no cover - Rhino callback
+        return __plugin_version__
+
+    def OnLoadPlugIn(self) -> Rhino.PlugIns.LoadReturnCode:  # pragma: no cover
+        # Register the alias so the command also appears in Rhino's alias list.
+        send_to_prusa._ensure_command_alias()
+        return Rhino.PlugIns.LoadReturnCode.Success
+
+
+class SendToPrusaCommand(Rhino.Commands.Command):
+    """Expose ``SendToPrusa`` as a Rhino command."""
+
+    instance: "SendToPrusaCommand" | None = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        SendToPrusaCommand.instance = self
+
+    def EnglishName(self) -> str:  # pragma: no cover - Rhino callback
+        return _SEND_ALIAS
+
+    def RunCommand(  # pragma: no cover - Rhino callback
+        self, doc: Rhino.RhinoDoc, mode: Rhino.Commands.RunMode
+    ) -> Rhino.Commands.Result:
+        return send_to_prusa.send_to_prusaslicer()
+
+
+class ConfigurePrusaPathCommand(Rhino.Commands.Command):
+    """Expose ``SendToPrusaSetPath`` to update the slicer executable."""
+
+    instance: "ConfigurePrusaPathCommand" | None = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        ConfigurePrusaPathCommand.instance = self
+
+    def EnglishName(self) -> str:  # pragma: no cover - Rhino callback
+        return _CONFIGURE_COMMAND
+
+    def RunCommand(  # pragma: no cover - Rhino callback
+        self, doc: Rhino.RhinoDoc, mode: Rhino.Commands.RunMode
+    ) -> Rhino.Commands.Result:
+        path = send_to_prusa.set_prusaslicer_path()
+        return Rhino.Commands.Result.Success if path else Rhino.Commands.Result.Cancel
+
+
+# Instantiate the commands so Rhino registers them when the plug-in loads.
+RhinoToPrusaPlugIn()
+SendToPrusaCommand()
+ConfigurePrusaPathCommand()

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -1,8 +1,8 @@
 """Rhino CPython plug-in entry point for the Rhino ➜ PrusaSlicer bridge."""
-from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Optional
 
 import Rhino
 import System
@@ -31,7 +31,7 @@ _CONFIGURE_COMMAND = f"{_SEND_ALIAS}SetPath"
 class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
     """Minimal plug-in that exposes the Prusa commands in Rhino."""
 
-    instance: "RhinoToPrusaPlugIn" | None = None
+    instance: Optional["RhinoToPrusaPlugIn"] = None
 
     def __init__(self) -> None:
         super().__init__()
@@ -58,7 +58,7 @@ class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
 class SendToPrusaCommand(Rhino.Commands.Command):
     """Expose ``SendToPrusa`` as a Rhino command."""
 
-    instance: "SendToPrusaCommand" | None = None
+    instance: Optional["SendToPrusaCommand"] = None
 
     def __init__(self) -> None:
         super().__init__()
@@ -76,7 +76,7 @@ class SendToPrusaCommand(Rhino.Commands.Command):
 class ConfigurePrusaPathCommand(Rhino.Commands.Command):
     """Expose ``SendToPrusaSetPath`` to update the slicer executable."""
 
-    instance: "ConfigurePrusaPathCommand" | None = None
+    instance: Optional["ConfigurePrusaPathCommand"] = None
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -1,8 +1,7 @@
 """Rhino CPython plug-in entry point for the Rhino ➜ PrusaSlicer bridge."""
 
+import os
 import sys
-from pathlib import Path
-from typing import Optional
 
 import Rhino
 import System
@@ -12,9 +11,9 @@ import System
 # which also contains ``send_to_prusa.py``. Some Rhino configurations do not
 # automatically append that folder to ``sys.path`` when running CPython plug-ins,
 # so add it explicitly to keep imports reliable.
-_PLUGIN_DIR = Path(__file__).resolve().parent
-if str(_PLUGIN_DIR) not in sys.path:
-    sys.path.insert(0, str(_PLUGIN_DIR))
+_PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+if _PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, _PLUGIN_DIR)
 
 import send_to_prusa  # noqa: E402  # pylint: disable=wrong-import-position
 
@@ -31,25 +30,25 @@ _CONFIGURE_COMMAND = send_to_prusa.SET_PATH_COMMAND_NAME
 class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
     """Minimal plug-in that exposes the Prusa commands in Rhino."""
 
-    instance: Optional["RhinoToPrusaPlugIn"] = None
+    instance = None
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         RhinoToPrusaPlugIn.instance = self
 
     @property
-    def Id(self) -> System.Guid:  # pragma: no cover - Rhino callback
+    def Id(self):  # pragma: no cover - Rhino callback
         return _PLUGIN_GUID
 
     @property
-    def PlugInName(self) -> str:  # pragma: no cover - Rhino callback
+    def PlugInName(self):  # pragma: no cover - Rhino callback
         return __plugin_name__
 
     @property
-    def Version(self) -> str:  # pragma: no cover - Rhino callback
+    def Version(self):  # pragma: no cover - Rhino callback
         return __plugin_version__
 
-    def OnLoadPlugIn(self) -> Rhino.PlugIns.LoadReturnCode:  # pragma: no cover
+    def OnLoadPlugIn(self):  # pragma: no cover
         # Register the alias so the command also appears in Rhino's alias list.
         send_to_prusa._ensure_command_alias()
         return Rhino.PlugIns.LoadReturnCode.Success
@@ -58,36 +57,36 @@ class RhinoToPrusaPlugIn(Rhino.PlugIns.PlugIn):
 class SendToPrusaCommand(Rhino.Commands.Command):
     """Expose ``SendToPrusa`` as a Rhino command."""
 
-    instance: Optional["SendToPrusaCommand"] = None
+    instance = None
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         SendToPrusaCommand.instance = self
 
-    def EnglishName(self) -> str:  # pragma: no cover - Rhino callback
+    def EnglishName(self):  # pragma: no cover - Rhino callback
         return _SEND_ALIAS
 
     def RunCommand(  # pragma: no cover - Rhino callback
-        self, doc: Rhino.RhinoDoc, mode: Rhino.Commands.RunMode
-    ) -> Rhino.Commands.Result:
+        self, doc, mode
+    ):
         return send_to_prusa.send_to_prusaslicer()
 
 
 class ConfigurePrusaPathCommand(Rhino.Commands.Command):
     """Expose ``SendToPrusaSetPath`` to update the slicer executable."""
 
-    instance: Optional["ConfigurePrusaPathCommand"] = None
+    instance = None
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         ConfigurePrusaPathCommand.instance = self
 
-    def EnglishName(self) -> str:  # pragma: no cover - Rhino callback
+    def EnglishName(self):  # pragma: no cover - Rhino callback
         return _CONFIGURE_COMMAND
 
     def RunCommand(  # pragma: no cover - Rhino callback
-        self, doc: Rhino.RhinoDoc, mode: Rhino.Commands.RunMode
-    ) -> Rhino.Commands.Result:
+        self, doc, mode
+    ):
         path = send_to_prusa.set_prusaslicer_path()
         return Rhino.Commands.Result.Success if path else Rhino.Commands.Result.Cancel
 

--- a/src/__plugin__.py
+++ b/src/__plugin__.py
@@ -1,4 +1,4 @@
-"""Rhino CPython plug-in entry point for the Rhino ➜ PrusaSlicer bridge."""
+"""Rhino CPython plug-in entry point for the Rhino to PrusaSlicer bridge."""
 
 import os
 import sys

--- a/src/send_to_prusa.py
+++ b/src/send_to_prusa.py
@@ -1,0 +1,272 @@
+"""Send selected Rhino geometry to PrusaSlicer.
+
+This module provides helper functions that can be executed from Rhino's Python
+script editor or bound to toolbar buttons. The main entry point is the
+``send_to_prusaslicer`` function which exports the current selection to a
+STEP file and launches PrusaSlicer with the exported model.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Optional
+
+import Rhino
+import rhinoscriptsyntax as rs
+import scriptcontext as sc
+import System
+
+
+_PRUSA_PATH_KEY = "RhinoToSlicer::PrusaPath"
+_ENV_PATH_KEY = "PRUSA_SLICER_PATH"
+_DEFAULT_EXTENSION = ".step"
+_MAC_APP_SUFFIX = ".app"
+_MAC_APP_EXECUTABLE = os.path.join("Contents", "MacOS", "PrusaSlicer")
+_CONFIG_FILENAME = "send_to_prusa_config.json"
+_ALIAS_NAME = "SendToPrusa"
+_ALIAS_MACRO = '! _SendToPrusa'
+
+
+def _is_windows() -> bool:
+    return System.Environment.OSVersion.Platform == System.PlatformID.Win32NT
+
+
+def _is_macos() -> bool:
+    platform = System.Environment.OSVersion.Platform
+    return platform == System.PlatformID.MacOSX or platform == System.PlatformID.Unix
+
+
+def _normalize_prusa_path(path: str) -> Optional[str]:
+    if not path:
+        return None
+    path = os.path.expanduser(path)
+    if _is_macos():
+        lower = path.lower()
+        if lower.endswith(_MAC_APP_SUFFIX):
+            if os.path.isdir(path):
+                app_binary = os.path.join(path, _MAC_APP_EXECUTABLE)
+                if os.path.isfile(app_binary) or os.access(app_binary, os.X_OK):
+                    return os.path.normpath(path)
+            return None
+        if os.path.isfile(path) or os.access(path, os.X_OK):
+            return os.path.normpath(path)
+        return None
+    if os.path.isfile(path) or os.access(path, os.X_OK):
+        return os.path.normpath(path)
+    return None
+
+
+def _config_path() -> Path:
+    try:
+        script_path = Path(__file__).resolve()
+    except (NameError, RuntimeError):  # pragma: no cover - fallback when __file__ missing
+        return Path(tempfile.gettempdir()) / _CONFIG_FILENAME
+    return script_path.with_name(_CONFIG_FILENAME)
+
+
+def _load_configured_path() -> Optional[str]:
+    config_path = _config_path()
+    if not config_path.exists():
+        return None
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    configured = payload.get("prusa_path")
+    return _normalize_prusa_path(configured) if configured else None
+
+
+def _store_configured_path(path: str) -> None:
+    config_path = _config_path()
+    payload = json.dumps({"prusa_path": path}, indent=2)
+    try:
+        config_path.write_text(payload, encoding="utf-8")
+    except OSError:
+        print("Unable to persist the PrusaSlicer path next to the helper script.")
+
+
+def _load_prusaslicer_path() -> Optional[str]:
+    env_path = os.environ.get(_ENV_PATH_KEY)
+    env_path = _normalize_prusa_path(env_path) if env_path else None
+    if env_path:
+        sc.sticky[_PRUSA_PATH_KEY] = env_path
+        return env_path
+
+    config_path = _load_configured_path()
+    if config_path:
+        sc.sticky[_PRUSA_PATH_KEY] = config_path
+        return config_path
+
+    sticky_path = sc.sticky.get(_PRUSA_PATH_KEY)
+    sticky_path = _normalize_prusa_path(sticky_path) if sticky_path else None
+    if sticky_path:
+        sc.sticky[_PRUSA_PATH_KEY] = sticky_path
+        return sticky_path
+    return None
+
+
+def _prompt_for_prusaslicer() -> Optional[str]:
+    if _is_windows():
+        filter_string = "PrusaSlicer executable (*.exe)|*.exe||"
+    elif _is_macos():
+        filter_string = "PrusaSlicer (*.app;PrusaSlicer)|*.app;PrusaSlicer||"
+    else:
+        filter_string = "Executable (*.*)|*.*||"
+
+    path = rs.OpenFileName("Locate PrusaSlicer", filter_string)
+    if not path:
+        return None
+    return _normalize_prusa_path(path)
+
+
+def set_prusaslicer_path(path: Optional[str] = None) -> Optional[str]:
+    """Persist the path to the PrusaSlicer executable.
+
+    If *path* is omitted a file dialog is presented. The chosen path is stored
+    in Rhino's sticky dictionary so that future calls can reuse it. The helper
+    also respects the :data:`PRUSA_SLICER_PATH` environment variable.
+    """
+    if path:
+        candidate = _normalize_prusa_path(path)
+    else:
+        candidate = _prompt_for_prusaslicer()
+    if not candidate:
+        print("PrusaSlicer path not set.")
+        return None
+
+    sc.sticky[_PRUSA_PATH_KEY] = candidate
+    _store_configured_path(candidate)
+    print("Stored PrusaSlicer path: {}".format(candidate))
+    return candidate
+
+
+@contextmanager
+def _preserve_selection(new_selection: Iterable) -> Iterable:
+    previous = rs.SelectedObjects() or []
+    try:
+        rs.UnselectAllObjects()
+        if new_selection:
+            rs.SelectObjects(list(new_selection))
+        yield new_selection
+    finally:
+        rs.UnselectAllObjects()
+        if previous:
+            rs.SelectObjects(previous)
+
+
+def _export_selection(temp_path: str) -> bool:
+    options = Rhino.FileIO.FileWriteOptions()
+    options.WriteSelectedObjectsOnly = True
+    options.SuppressDialogBoxes = True
+    if sc.doc.ExportSelected(temp_path, options):
+        return os.path.exists(temp_path)
+    return False
+
+
+def _create_temp_export_path(extension: str = _DEFAULT_EXTENSION) -> str:
+    filename = "RhinoToPrusa_{}{}".format(uuid.uuid4().hex, extension)
+    return os.path.join(tempfile.gettempdir(), filename)
+
+
+def _ensure_command_alias() -> None:
+    macro = _ALIAS_MACRO
+    try:
+        alias_table = Rhino.ApplicationSettings.CommandAliases
+    except AttributeError:
+        alias_table = None
+    if alias_table is not None:
+        try:
+            if alias_table.Contains(_ALIAS_NAME):
+                existing = alias_table.GetMacro(_ALIAS_NAME)
+                if existing == macro:
+                    return
+                print(
+                    "Rhino alias '{}' already exists with a different macro; leaving it unchanged.".format(
+                        _ALIAS_NAME
+                    )
+                )
+                return
+            if alias_table.Add(_ALIAS_NAME, macro):
+                print("Registered Rhino alias '{}'".format(_ALIAS_NAME))
+                return
+            alias_table.SetMacro(_ALIAS_NAME, macro)
+            print("Registered Rhino alias '{}'".format(_ALIAS_NAME))
+            return
+        except Exception:
+            alias_table = None
+    command = '-Alias "{}" "{}"'.format(_ALIAS_NAME, macro.replace('"', '""'))
+    try:
+        if Rhino.RhinoApp.RunScript(command, False):
+            print("Registered Rhino alias '{}'".format(_ALIAS_NAME))
+    except Exception:
+        pass
+
+
+def _launch_prusaslicer(prusa_path: str, model_path: str) -> None:
+    try:
+        if _is_macos():
+            lower = prusa_path.lower()
+            if lower.endswith(_MAC_APP_SUFFIX):
+                subprocess.Popen(["open", "-a", prusa_path, model_path])
+                return
+        subprocess.Popen([prusa_path, model_path])
+    except OSError as exc:
+        raise RuntimeError("Unable to start PrusaSlicer: {}".format(exc))
+
+
+def send_to_prusaslicer() -> Rhino.Commands.Result:
+    """Export the selected geometry to STEP and open it in PrusaSlicer."""
+    _ensure_command_alias()
+    objects = rs.GetObjects(
+        "Select objects to send to PrusaSlicer",
+        preselect=True,
+        select=False,
+        minimum_count=1,
+    )
+    if not objects:
+        print("No geometry selected.")
+        return Rhino.Commands.Result.Cancel
+
+    prusa_path = _load_prusaslicer_path()
+    if not prusa_path:
+        prusa_path = set_prusaslicer_path()
+    if not prusa_path:
+        return Rhino.Commands.Result.Cancel
+
+    export_path = _create_temp_export_path()
+
+    with _preserve_selection(objects):
+        success = _export_selection(export_path)
+    if not success:
+        if os.path.exists(export_path):
+            try:
+                os.remove(export_path)
+            except OSError:
+                pass
+        print("Export failed. Check that the STEP exporter is installed and licensed.")
+        return Rhino.Commands.Result.Failure
+
+    try:
+        _launch_prusaslicer(prusa_path, export_path)
+    except RuntimeError as exc:
+        print(str(exc))
+        return Rhino.Commands.Result.Failure
+
+    print("Exported {} objects to {} and launched PrusaSlicer.".format(len(objects), export_path))
+    return Rhino.Commands.Result.Success
+
+
+__commandname__ = _ALIAS_NAME
+
+
+def RunCommand(is_interactive: bool) -> Rhino.Commands.Result:
+    return send_to_prusaslicer()
+
+
+if __name__ == "__main__":
+    send_to_prusaslicer()

--- a/src/send_to_prusa.py
+++ b/src/send_to_prusa.py
@@ -28,6 +28,7 @@ _MAC_APP_SUFFIX = ".app"
 _MAC_APP_EXECUTABLE = os.path.join("Contents", "MacOS", "PrusaSlicer")
 _CONFIG_FILENAME = "send_to_prusa_config.json"
 _ALIAS_NAME = "SendToPrusa"
+SET_PATH_COMMAND_NAME = f"{_ALIAS_NAME}SetPath"
 _ALIAS_MACRO = '! _SendToPrusa'
 
 

--- a/src/send_to_prusa.py
+++ b/src/send_to_prusa.py
@@ -5,7 +5,6 @@ script editor or bound to toolbar buttons. The main entry point is the
 ``send_to_prusaslicer`` function which exports the current selection to a
 STEP file and launches PrusaSlicer with the exported model.
 """
-from __future__ import annotations
 
 import json
 import os

--- a/src/send_to_prusa.py
+++ b/src/send_to_prusa.py
@@ -12,8 +12,6 @@ import subprocess
 import tempfile
 import uuid
 from contextlib import contextmanager
-from pathlib import Path
-from typing import Iterable, Optional
 
 import Rhino
 import rhinoscriptsyntax as rs
@@ -28,20 +26,20 @@ _MAC_APP_SUFFIX = ".app"
 _MAC_APP_EXECUTABLE = os.path.join("Contents", "MacOS", "PrusaSlicer")
 _CONFIG_FILENAME = "send_to_prusa_config.json"
 _ALIAS_NAME = "SendToPrusa"
-SET_PATH_COMMAND_NAME = f"{_ALIAS_NAME}SetPath"
+SET_PATH_COMMAND_NAME = "{}SetPath".format(_ALIAS_NAME)
 _ALIAS_MACRO = '! _SendToPrusa'
 
 
-def _is_windows() -> bool:
+def _is_windows():
     return System.Environment.OSVersion.Platform == System.PlatformID.Win32NT
 
 
-def _is_macos() -> bool:
+def _is_macos():
     platform = System.Environment.OSVersion.Platform
     return platform == System.PlatformID.MacOSX or platform == System.PlatformID.Unix
 
 
-def _normalize_prusa_path(path: str) -> Optional[str]:
+def _normalize_prusa_path(path):
     if not path:
         return None
     path = os.path.expanduser(path)
@@ -61,36 +59,38 @@ def _normalize_prusa_path(path: str) -> Optional[str]:
     return None
 
 
-def _config_path() -> Path:
+def _config_path():
     try:
-        script_path = Path(__file__).resolve()
+        script_path = os.path.abspath(__file__)
     except (NameError, RuntimeError):  # pragma: no cover - fallback when __file__ missing
-        return Path(tempfile.gettempdir()) / _CONFIG_FILENAME
-    return script_path.with_name(_CONFIG_FILENAME)
+        return os.path.join(tempfile.gettempdir(), _CONFIG_FILENAME)
+    return os.path.join(os.path.dirname(script_path), _CONFIG_FILENAME)
 
 
-def _load_configured_path() -> Optional[str]:
+def _load_configured_path():
     config_path = _config_path()
-    if not config_path.exists():
+    if not os.path.exists(config_path):
         return None
     try:
-        payload = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        with open(config_path, "r") as stream:
+            payload = json.load(stream)
+    except (OSError, ValueError):
         return None
     configured = payload.get("prusa_path")
     return _normalize_prusa_path(configured) if configured else None
 
 
-def _store_configured_path(path: str) -> None:
+def _store_configured_path(path):
     config_path = _config_path()
     payload = json.dumps({"prusa_path": path}, indent=2)
     try:
-        config_path.write_text(payload, encoding="utf-8")
+        with open(config_path, "w") as stream:
+            stream.write(payload)
     except OSError:
         print("Unable to persist the PrusaSlicer path next to the helper script.")
 
 
-def _load_prusaslicer_path() -> Optional[str]:
+def _load_prusaslicer_path():
     env_path = os.environ.get(_ENV_PATH_KEY)
     env_path = _normalize_prusa_path(env_path) if env_path else None
     if env_path:
@@ -110,7 +110,7 @@ def _load_prusaslicer_path() -> Optional[str]:
     return None
 
 
-def _prompt_for_prusaslicer() -> Optional[str]:
+def _prompt_for_prusaslicer():
     if _is_windows():
         filter_string = "PrusaSlicer executable (*.exe)|*.exe||"
     elif _is_macos():
@@ -124,7 +124,7 @@ def _prompt_for_prusaslicer() -> Optional[str]:
     return _normalize_prusa_path(path)
 
 
-def set_prusaslicer_path(path: Optional[str] = None) -> Optional[str]:
+def set_prusaslicer_path(path=None):
     """Persist the path to the PrusaSlicer executable.
 
     If *path* is omitted a file dialog is presented. The chosen path is stored
@@ -146,7 +146,7 @@ def set_prusaslicer_path(path: Optional[str] = None) -> Optional[str]:
 
 
 @contextmanager
-def _preserve_selection(new_selection: Iterable) -> Iterable:
+def _preserve_selection(new_selection):
     previous = rs.SelectedObjects() or []
     try:
         rs.UnselectAllObjects()
@@ -159,7 +159,7 @@ def _preserve_selection(new_selection: Iterable) -> Iterable:
             rs.SelectObjects(previous)
 
 
-def _export_selection(temp_path: str) -> bool:
+def _export_selection(temp_path):
     options = Rhino.FileIO.FileWriteOptions()
     options.WriteSelectedObjectsOnly = True
     options.SuppressDialogBoxes = True
@@ -168,12 +168,12 @@ def _export_selection(temp_path: str) -> bool:
     return False
 
 
-def _create_temp_export_path(extension: str = _DEFAULT_EXTENSION) -> str:
+def _create_temp_export_path(extension=_DEFAULT_EXTENSION):
     filename = "RhinoToPrusa_{}{}".format(uuid.uuid4().hex, extension)
     return os.path.join(tempfile.gettempdir(), filename)
 
 
-def _ensure_command_alias() -> None:
+def _ensure_command_alias():
     macro = _ALIAS_MACRO
     try:
         alias_table = Rhino.ApplicationSettings.CommandAliases
@@ -207,7 +207,7 @@ def _ensure_command_alias() -> None:
         pass
 
 
-def _launch_prusaslicer(prusa_path: str, model_path: str) -> None:
+def _launch_prusaslicer(prusa_path, model_path):
     try:
         if _is_macos():
             lower = prusa_path.lower()
@@ -219,7 +219,7 @@ def _launch_prusaslicer(prusa_path: str, model_path: str) -> None:
         raise RuntimeError("Unable to start PrusaSlicer: {}".format(exc))
 
 
-def send_to_prusaslicer() -> Rhino.Commands.Result:
+def send_to_prusaslicer():
     """Export the selected geometry to STEP and open it in PrusaSlicer."""
     _ensure_command_alias()
     objects = rs.GetObjects(
@@ -264,7 +264,7 @@ def send_to_prusaslicer() -> Rhino.Commands.Result:
 __commandname__ = _ALIAS_NAME
 
 
-def RunCommand(is_interactive: bool) -> Rhino.Commands.Result:
+def RunCommand(is_interactive):
     return send_to_prusaslicer()
 
 

--- a/src/send_to_prusa_set_path.py
+++ b/src/send_to_prusa_set_path.py
@@ -1,0 +1,17 @@
+"""Rhino command shim that updates the PrusaSlicer executable path."""
+
+import Rhino
+
+import send_to_prusa
+
+
+__commandname__ = send_to_prusa.SET_PATH_COMMAND_NAME
+
+
+def RunCommand(is_interactive: bool) -> Rhino.Commands.Result:  # pragma: no cover - Rhino callback
+    path = send_to_prusa.set_prusaslicer_path()
+    return Rhino.Commands.Result.Success if path else Rhino.Commands.Result.Cancel
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    RunCommand(True)

--- a/src/send_to_prusa_set_path.py
+++ b/src/send_to_prusa_set_path.py
@@ -8,7 +8,7 @@ import send_to_prusa
 __commandname__ = send_to_prusa.SET_PATH_COMMAND_NAME
 
 
-def RunCommand(is_interactive: bool) -> Rhino.Commands.Result:  # pragma: no cover - Rhino callback
+def RunCommand(is_interactive):  # pragma: no cover - Rhino callback
     path = send_to_prusa.set_prusaslicer_path()
     return Rhino.Commands.Result.Success if path else Rhino.Commands.Result.Cancel
 

--- a/src/send_to_prusa_set_path.py
+++ b/src/send_to_prusa_set_path.py
@@ -10,7 +10,9 @@ __commandname__ = send_to_prusa.SET_PATH_COMMAND_NAME
 
 def RunCommand(is_interactive):  # pragma: no cover - Rhino callback
     path = send_to_prusa.set_prusaslicer_path()
-    return Rhino.Commands.Result.Success if path else Rhino.Commands.Result.Cancel
+    if path:
+        return Rhino.Commands.Result.Success
+    return Rhino.Commands.Result.Cancel
 
 
 if __name__ == "__main__":  # pragma: no cover - convenience entry point


### PR DESCRIPTION
## Summary
- package the helper as a Rhino CPython plug-in that exposes SendToPrusa and SendToPrusaSetPath commands
- update the installer to deploy the plug-in into Rhino's PythonPlugIns folder and wire the SendToPrusa alias to the command
- refresh the documentation to describe the plug-in workflow and add the CPython plug-in entry module

## Testing
- `python -m compileall src/send_to_prusa.py src/__plugin__.py install.py`


------
https://chatgpt.com/codex/tasks/task_e_68d39e9abbd483238803c839f6092e0f